### PR TITLE
Make removed content easier to see

### DIFF
--- a/public/assets/stylesheets/docs.css
+++ b/public/assets/stylesheets/docs.css
@@ -80,6 +80,7 @@ ol > .fix::before {
 .removed {
 	text-decoration: line-through;
 	color:var(--red);
+	background-color:var(--light-red);
 }
 
 .new {


### PR DESCRIPTION
Perhaps a function of mild color blindness, but it's fairly difficult to see removed content in the current site at a glance. It's not so bad when it's a text _replacement_ ("tournament" in the screenshots) since additions right next to it are very easy to see, but if something is just removed ("or sideboard" in the screenshots), it's more difficult. Especially egregious is the current MTR update, which is basically only removal of tournament names.

It might make sense to adapt `.old` for the CR side-by-side diff similarly for consistency. At least those sections tend to be shorter.

Tested only in my browser's web dev console; otherwise untested.

A different choice of front/back color combination might improve contrast and therefore legibility over this proposal.

<details><summary>Before</summary>

![Screenshot](https://user-images.githubusercontent.com/1831569/73144044-606eae00-40a1-11ea-81b0-f3d1da906a64.png)
</details>

<details><summary>After</summary>

![Screenshot](https://user-images.githubusercontent.com/1831569/73144048-6fedf700-40a1-11ea-8988-e649b2e861cc.png)
</details>
