### PR TITLE
MTR Parser Improvements

### DIFF
--- a/scraper/test/test_mtr.py
+++ b/scraper/test/test_mtr.py
@@ -8,19 +8,19 @@ def test_parse_mtr():
 
     # The effective date should have the right type
     assert isinstance(mtr.effective, datetime.date)
-    assert mtr.sections[0].name.name == "Introduction"
+    assert mtr.sections[0].metadata.name == "Introduction"
 
     for i, section in enumerate(mtr.sections):
         assert isinstance(section, Section)
         # Have to disable this for now because of chapter 3.8
-        # assert len(section.content) > 10
+        assert len(section.content) > 10
         if i > 1:
             # Ensure we haven't skipped a section
-            curr_num = re.split("[.\s]", section.name.num)
-            prev_num = re.split("[.\s]", mtr.sections[i - 1].name.num)
+            curr_num = re.split("[.\s]", section.metadata.num)
+            prev_num = re.split("[.\s]", mtr.sections[i - 1].metadata.num)
 
             # One of the numbers or letters in the section number must be greater than the previous
-            if "Appendix" in section.name.num:
+            if "Appendix" in section.metadata.num:
                 assert curr_num[1] > prev_num[1]
             else:
                 assert int(curr_num[0]) > int(prev_num[0]) or int(curr_num[1]) > int(prev_num[1])

--- a/scraper/vensers_journal_mtr_scraper/mtr.py
+++ b/scraper/vensers_journal_mtr_scraper/mtr.py
@@ -1,5 +1,6 @@
 import datetime
 import sys
+import re
 
 import requests
 from pdfminer import high_level
@@ -94,6 +95,14 @@ def process_elements(els: list) -> Mtr:
             )
         elif isinstance(el, Effective):
             mtr.effective = el.effective
+
+    # Now we've compiled the sections, fix the newlines
+    for section in mtr.sections:
+        # Delete incorrect newlines: those that are neither preceded by two spaces nor followed by a dot point
+        section.content = re.sub('((?<!  )\\n)(?!\\u2022)', "", section.content)
+        # Fix correct newlines
+        section.content = re.sub('  \\n', "\n", section.content)
+
     return mtr
 
 


### PR DESCRIPTION
* Fix layout order to populate broken sections
* Rename "name" as a top level section field to "metadata"
* Remove a lot of false newlines from the content
* Known issue: numbered lists aren't being parsed correctly, e.g. in section 3.1 Tiebreakers
* Sample JSON: [scrape.json.txt](https://github.com/Villawhatever/VensersJournal/files/7836201/scrape.json.txt)

